### PR TITLE
fixed bug

### DIFF
--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -64,7 +64,7 @@
                             <a class="nav-link dropdown-toggle text-dark" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Profile</a>
                             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                                 <a class="dropdown-item" asp-controller="PaymentTypes" asp-action="Index">Payment Types</a>
-                                <a class="dropdown-item" asp-controller="PaymentTypes" asp-action="Index">Order History</a>
+                         
                             </div>
                         </li>
                     </ul>


### PR DESCRIPTION
# Description

removed order history from profile dropdown. you should just see payment types!
Related to Issue # 


# Testing Instructions



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
